### PR TITLE
fix showcases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Below is a list of curated resources for Vuetify. If you have something that you
   - [Misc](#misc)
 - Projects using Vuetify
   - [Open source](#open-source)
-  - [Showcases](#showcase)
+  - [Showcases](#showcases)
 
 ## Resources
 


### PR DESCRIPTION
just noticed a typo in the showcases bookmark link.