### PR TITLE
Fix mutfak-chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Below is a list of curated resources for Vuetify. If you have something that you
 - [Sozler.im](https://www.sozler.im) - quotes website built entirely with Vuetify
 - [thegaelicpoint.ie](https://thegaelicpoint.ie/) - Sports analytics tool built with Vuetify and Nuxt
 - [Blogram.me](https://blogram.me) - Iranian microblogging platform
-- [mutfak-chat.firebaseapp.com](https://mutfak-chat.firebaseapp.com/login) - A chat built with Vue + Vuex + Vuetify + Firebase
+- [mutfak-chat.firebaseapp.com](https://mutfak-chat.firebaseapp.com/) - A chat built with Vue + Vuex + Vuetify + Firebase
 
 ## Contribute
 


### PR DESCRIPTION
The link [https://mutfak-chat.firebaseapp.com/login](https://mutfak-chat.firebaseapp.com/login) redirect on a 404 error.

![preview.png](https://puu.sh/Ca6g9/559f15d97e.png)

This is fixed when we remove `/login`