### PR TITLE
Remove Facebook Link From Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ If you have something that you think belongs here, feel free to reach out to us 
 ### Community
 - [Discord Chat](https://chat.vuetifyjs.com)
 - [Twitter](https://twitter.com/vuetifyjs)
-- [Facebook](https://www.facebook.com/vuetifyjs)
 - [StackOverflow](https://stackoverflow.com/questions/tagged/vuetify.js)
 
 ### Tutorials


### PR DESCRIPTION
Remove because it is no more available 