### PR TITLE
Add vuetify-datatable-extended to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ If you have something that you think belongs here, feel free to reach out to us 
 - [ShipIT](https://github.com/18chetanpatel/shipit) - Free E-Commerce Website Theme
 - [Sheiley Shop](https://github.com/itsalb3rt/sheiley_shop_app) - PWA to track personal purchases, No more paper and pencil to go to the supermarket 🏬 Vuetify 2.2 + Vue 2.6
 
+### Libraries
+- [vuetify-datatable-extended](https://github.com/benwinding/vuetify-datatable-extended) - Extended features for the `<v-datatable>` component (search, filters, etc..) 
+
 ### Showcases
 - [bit4you.io](https://www.bit4you.io) European crypto exchange using vuetify
 - [🐮Integrity Livestock Sales](https://www.integritylivestocksales.com/) - Live Auction Listings Site (Vuetify + Nuxt)


### PR DESCRIPTION
Hi Guys,

After using `<v-datatable>` for many different pages, I found I needed an abstraction over it to easily enable the search and filtering across all my tables (as they shared extremely similar implementations). 

This is why I created the [vuetify-datatable-extended](https://github.com/benwinding/vuetify-datatable-extended) package ([demo here](https://benwinding.github.io/vuetify-datatable-extended/)). It has the same interface as `<v-datatable>` component by passing through all the props and slots. However it also wires up:
- A search field
- Per field filtering
- Column selection

I hope this is alright to add to this awesome list, I added another heading in this README called **Libraries**.

Thanks for everything,.
Ben