### PR TITLE
Add httpSMS open source application

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you have something that you think belongs here, feel free to reach out to us 
 - [NocoDB](https://github.com/nocodb/nocodb) - A Free & Open Source Airtable Alternative ![Github](https://img.shields.io/github/stars/nocodb/nocodb?logo=github) ![Nuxt](https://img.shields.io/badge/Nuxt-00DC82.svg?logo=nuxtdotjs&logoColor=white) ![Typescript](https://img.shields.io/badge/Typescript-3178C6.svg?logo=typescript&logoColor=white)
 - [Open API Explorer](https://darosh.github.io/oax/#/) - OpenApi Specification Explorer
 - [Sheiley Shop](https://github.com/itsalb3rt/sheiley_shop_app) - PWA to track personal purchases
+- [httpSMS](https://github.com/ndolestudio/httpsms) - Use your Android phone to send and receive SMS messages via an HTTP API ![Nuxt](https://img.shields.io/badge/Nuxt-00DC82.svg?logo=nuxtdotjs&logoColor=white) ![Typescript](https://img.shields.io/badge/Typescript-3178C6.svg?logo=typescript&logoColor=white) 
 
 ### Vuetify 3
 


### PR DESCRIPTION
This PR adds the httpSMS repo in the list of examples with nuxt.JS and Vuetify.